### PR TITLE
Fix editor drag and drop

### DIFF
--- a/private/editor.html
+++ b/private/editor.html
@@ -1054,6 +1054,6 @@
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/table@latest/dist/table.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sanitize-html@latest/dist/sanitize-html.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
-    <script type="module" src="/editor.js"></script>
+    <script src="/editor.js"></script>
 </body>
 </html>

--- a/public/editor.js
+++ b/public/editor.js
@@ -1,19 +1,7 @@
 // editor.js
-import EditorJS from '@editorjs/editorjs';
-import Header from '@editorjs/header';
-import List from '@editorjs/list';
-import ImageTool from '@editorjs/image';
-import Table from '@editorjs/table';
-import ChartJS from 'chart.js/auto';
-import html2pdf from 'html2pdf.js';
-import $ from 'jquery';
-import 'jquery-ui/ui/widgets/draggable';
-import 'jquery-ui/ui/widgets/resizable';
-import sanitizeHtml from 'sanitize-html';
-import 'bootstrap/dist/js/bootstrap.bundle.min.js';
-import 'animate.css';
-import * as XLSX from 'xlsx';
-import JSZip from 'jszip';
+// All required libraries are included via CDN in editor.html, so we rely on
+// the global variables they expose instead of using ES module imports. This
+// keeps the script simple and avoids the need for a build step.
 
 // Initialize global variables
 window.editors = [];


### PR DESCRIPTION
## Summary
- reference CDN libraries directly instead of using ES module imports
- update HTML to load editor script without module type

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bbabe75f0832db024bbfeeb1bdf66