### PR TITLE
Implement template API

### DIFF
--- a/app.js
+++ b/app.js
@@ -238,6 +238,7 @@ async function ensureIndexes(db) {
   await db.collection('forms').createIndex({ userId: 1, createdAt: -1 });
   await db.collection('form_submissions').createIndex({ formId: 1, createdAt: -1 });
   await db.collection('form_submissions').createIndex({ 'responses.fieldId': 1, 'responses.value': 1 }); // For email uniqueness
+  await db.collection('templates').createIndex({ userId: 1, createdAt: -1 });
 }
 
 async function registerUser(db, userData) {
@@ -909,6 +910,47 @@ async function deleteDocument(db, id, userId) {
   });
   if (result.deletedCount === 0) throw new Error('Documento no encontrado o no tienes permisos.');
   return { message: 'Documento eliminado.' };
+}
+
+// Template helpers
+async function createTemplate(db, templateData, userId) {
+  const template = {
+    ...templateData,
+    userId: new ObjectId(userId),
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+  const result = await db.collection('templates').insertOne(template);
+  return { message: 'Plantilla guardada.', insertedId: result.insertedId };
+}
+
+async function updateTemplate(db, id, templateData, userId) {
+  const result = await db.collection('templates').updateOne(
+    { _id: new ObjectId(id), userId: new ObjectId(userId) },
+    { $set: { ...templateData, updatedAt: new Date() } }
+  );
+  if (result.matchedCount === 0) throw new Error('Plantilla no encontrada o no tienes permisos.');
+  return { message: 'Plantilla actualizada.' };
+}
+
+async function getTemplate(db, id) {
+  return db.collection('templates').findOne({ _id: new ObjectId(id) });
+}
+
+async function getTemplates(db, userId) {
+  return db.collection('templates')
+    .find({ userId: new ObjectId(userId) })
+    .sort({ updatedAt: -1 })
+    .toArray();
+}
+
+async function deleteTemplate(db, id, userId) {
+  const result = await db.collection('templates').deleteOne({
+    _id: new ObjectId(id),
+    userId: new ObjectId(userId)
+  });
+  if (result.deletedCount === 0) throw new Error('Plantilla no encontrada o no tienes permisos.');
+  return { message: 'Plantilla eliminada.' };
 }
 
 async function getForm(db, id) {
@@ -1598,14 +1640,93 @@ app.delete('/api/documents/:id', requireAuth, async (req, res) => {
   }
 });
 
+// Template routes
+app.post('/api/templates', requireAuth, async (req, res) => {
+  try {
+    const result = await createTemplate(db, req.body, req.session.user._id);
+    res.status(201).json(result);
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
+app.get('/api/templates', requireAuth, async (req, res) => {
+  try {
+    const templates = await getTemplates(db, req.session.user._id);
+    res.json(templates);
+  } catch (error) {
+    res.status(500).json({ error: 'Error al obtener plantillas' });
+  }
+});
+
+app.get('/api/templates/:id', requireAuth, async (req, res) => {
+  try {
+    const template = await getTemplate(db, req.params.id);
+    if (!template) return res.status(404).json({ error: 'Plantilla no encontrada' });
+    res.json(template);
+  } catch (error) {
+    res.status(500).json({ error: 'Error al obtener plantilla' });
+  }
+});
+
+app.put('/api/templates/:id', requireAuth, async (req, res) => {
+  try {
+    const result = await updateTemplate(db, req.params.id, req.body, req.session.user._id);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
+app.delete('/api/templates/:id', requireAuth, async (req, res) => {
+  try {
+    const result = await deleteTemplate(db, req.params.id, req.session.user._id);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
 app.get('/api/stats', requireAuth, async (req, res) => {
   try {
-    const [pendingPayments, postCount, subscriberCount] = await Promise.all([
+    const start = new Date();
+    start.setDate(start.getDate() - 6);
+    start.setHours(0, 0, 0, 0);
+
+    const [pendingPayments, postCount, subscriberCount, paymentsDailyAgg, postsDailyAgg, subscribersDailyAgg] = await Promise.all([
       db.collection('form_submissions').countDocuments({ status: 'pending' }),
       db.collection('posts').countDocuments(),
-      db.collection('newsletter_subscribers').countDocuments({ subscribed: true })
+      db.collection('newsletter_subscribers').countDocuments({ subscribed: true }),
+      db.collection('form_submissions').aggregate([
+        { $match: { status: 'pending', createdAt: { $gte: start } } },
+        { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, count: { $sum: 1 } } },
+        { $sort: { _id: 1 } }
+      ]).toArray(),
+      db.collection('posts').aggregate([
+        { $match: { createdAt: { $gte: start } } },
+        { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, count: { $sum: 1 } } },
+        { $sort: { _id: 1 } }
+      ]).toArray(),
+      db.collection('newsletter_subscribers').aggregate([
+        { $match: { createdAt: { $gte: start }, subscribed: true } },
+        { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, count: { $sum: 1 } } },
+        { $sort: { _id: 1 } }
+      ]).toArray()
     ]);
-    res.json({ pendingPayments, postCount, subscriberCount });
+
+    const formatDaily = (arr) => arr.reduce((acc, cur) => {
+      acc[cur._id] = cur.count;
+      return acc;
+    }, {});
+
+    res.json({
+      pendingPayments,
+      postCount,
+      subscriberCount,
+      paymentsDaily: formatDaily(paymentsDailyAgg),
+      postsDaily: formatDaily(postsDailyAgg),
+      subscribersDaily: formatDaily(subscribersDailyAgg)
+    });
   } catch (error) {
     res.status(500).json({ error: 'Error al obtener estadísticas' });
   }

--- a/private/dashboard.html
+++ b/private/dashboard.html
@@ -1098,6 +1098,18 @@
                         <h4>Actividad Reciente</h4>
                         <canvas id="activityChart" height="200"></canvas>
                     </div>
+
+                    <!-- Gráfico de pagos pendientes -->
+                    <div class="chart-container bounce-in" style="animation-delay: 0.5s;">
+                        <h4>Pagos Pendientes</h4>
+                        <canvas id="paymentsChart" height="200"></canvas>
+                    </div>
+
+                    <!-- Gráfico de usuarios boletín -->
+                    <div class="chart-container bounce-in" style="animation-delay: 0.6s;">
+                        <h4>Usuarios Boletín</h4>
+                        <canvas id="subscribersChart" height="200"></canvas>
+                    </div>
                 </div>
             </div>
         </div>
@@ -1210,70 +1222,64 @@
                     cards[0].textContent = stats.pendingPayments;
                     cards[1].textContent = stats.postCount;
                     cards[2].textContent = stats.subscriberCount;
+                    updateChart(activityChart, stats.postsDaily || {});
+                    updateChart(paymentsChart, stats.paymentsDaily || {});
+                    updateChart(subscribersChart, stats.subscribersDaily || {});
                 } catch(e) { console.error(e); }
             }
 
-            // Inicializar gráfico de actividad
-            try {
-                const activityChart = new Chart(document.getElementById('activityChart'), {
-                    type: 'line',
-                    data: {
-                        labels: [],
-                        datasets: [{
-                            label: 'Publicaciones',
-                            data: [],
-                            backgroundColor: 'rgba(230, 126, 34, 0.2)',
+            // Gráficos
+            const chartOptions = {
+                type: 'line',
+                data: { labels: [], datasets: [{ data: [],
+                    backgroundColor: 'rgba(230, 126, 34, 0.2)',
+                    borderColor: '#e67e22',
+                    borderWidth: 2,
+                    tension: 0.4,
+                    pointBackgroundColor: '#e67e22',
+                    pointBorderColor: '#fff',
+                    pointHoverBackgroundColor: '#fff',
+                    pointHoverBorderColor: '#e67e22',
+                    pointRadius: 4,
+                    pointHoverRadius: 6,
+                    fill: true }] },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            backgroundColor: '#232A40',
+                            titleColor: '#e67e22',
+                            bodyColor: '#fff',
                             borderColor: '#e67e22',
-                            borderWidth: 2,
-                            tension: 0.4,
-                            pointBackgroundColor: '#e67e22',
-                            pointBorderColor: '#fff',
-                            pointHoverBackgroundColor: '#fff',
-                            pointHoverBorderColor: '#e67e22',
-                            pointRadius: 4,
-                            pointHoverRadius: 6,
-                            fill: true
-                        }]
-                    },
-                    options: {
-                        responsive: true,
-                        maintainAspectRatio: true,
-                        plugins: {
-                            legend: { display: false },
-                            tooltip: {
-                                backgroundColor: '#232A40',
-                                titleColor: '#e67e22',
-                                bodyColor: '#fff',
-                                borderColor: '#e67e22',
-                                borderWidth: 1,
-                                cornerRadius: 8,
-                                displayColors: false,
-                                callbacks: {
-                                    title: function (tooltipItem) { return 'Día: ' + tooltipItem[0].label; },
-                                    label: function (context) { return 'Actividad: ' + context.raw; }
-                                }
+                            borderWidth: 1,
+                            cornerRadius: 8,
+                            displayColors: false,
+                            callbacks: {
+                                title: (items) => 'Día: ' + items[0].label,
+                                label: (ctx) => 'Cantidad: ' + ctx.raw
                             }
-                        },
-                        scales: {
-                            x: { grid: { color: 'rgba(255, 255, 255, 0.05)' }, ticks: { color: 'rgba(255, 255, 255, 0.7)' } },
-                            y: { grid: { color: 'rgba(255, 255, 255, 0.05)' }, ticks: { color: 'rgba(255, 255, 255, 0.7)' } }
                         }
+                    },
+                    scales: {
+                        x: { grid: { color: 'rgba(255, 255, 255, 0.05)' }, ticks: { color: 'rgba(255, 255, 255, 0.7)' } },
+                        y: { grid: { color: 'rgba(255, 255, 255, 0.05)' }, ticks: { color: 'rgba(255, 255, 255, 0.7)' } }
                     }
-                });
-                try {
-                    const res = await fetch('/api/posts');
-                    const posts = await res.json();
-                    const counts = {};
-                    posts.forEach(p => {
-                        const d = new Date(p.createdAt).toLocaleDateString('es-ES');
-                        counts[d] = (counts[d] || 0) + 1;
-                    });
-                    activityChart.data.labels = Object.keys(counts);
-                    activityChart.data.datasets[0].data = Object.values(counts);
-                    activityChart.update();
-                } catch(e) { console.error(e); }
-            } catch (error) {
-                console.error('Error al inicializar el gráfico:', error);
+                }
+            };
+
+            const activityChart = new Chart(document.getElementById('activityChart'), JSON.parse(JSON.stringify(chartOptions)));
+            activityChart.data.datasets[0].label = 'Publicaciones';
+            const paymentsChart = new Chart(document.getElementById('paymentsChart'), JSON.parse(JSON.stringify(chartOptions)));
+            paymentsChart.data.datasets[0].label = 'Pagos';
+            const subscribersChart = new Chart(document.getElementById('subscribersChart'), JSON.parse(JSON.stringify(chartOptions)));
+            subscribersChart.data.datasets[0].label = 'Suscriptores';
+
+            function updateChart(chart, data) {
+                chart.data.labels = Object.keys(data);
+                chart.data.datasets[0].data = Object.values(data);
+                chart.update();
             }
 
             // Toggle sidebar

--- a/private/dashboard_pagos.html
+++ b/private/dashboard_pagos.html
@@ -460,11 +460,6 @@
                     <label class="form-label">Formulario</label>
                     <select class="form-select" id="formFilter">
                         <option value="">Todos los formularios</option>
-                        <option value="ingles-basico">Inglés Básico</option>
-                        <option value="ingles-intermedio">Inglés Intermedio</option>
-                        <option value="frances-basico">Francés Básico</option>
-                        <option value="curso-verano">Curso de Verano</option>
-                        <option value="intensivo-sabatino">Intensivo Sabatino</option>
                     </select>
                 </div>
                 <div class="col-md-3 mb-3">
@@ -599,22 +594,63 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         let paymentsData = [];
-        async function loadPayments() {
+        let formsMap = {};
+        async function loadData() {
             try {
-                const response = await fetch('/api/form-submissions');
-                if (!response.ok) throw new Error('No se pudieron obtener los registros');
-                const raw = await response.json();
-                paymentsData = raw.map(s => ({
-                    id: s._id,
-                    student: s.responses[0]?.value || 'N/A',
-                    formName: s.formId,
-                    captureNumber: s.responses[1]?.value || '',
-                    govValidation: 'pending',
-                    date: s.createdAt,
-                    status: s.status,
-                    files: s.files || [],
-                    observations: []
-                }));
+                const [formsRes, submissionsRes] = await Promise.all([
+                    fetch('/api/forms?formType=payment'),
+                    fetch('/api/form-submissions')
+                ]);
+                if (!formsRes.ok || !submissionsRes.ok) throw new Error('No se pudieron obtener los registros');
+
+                const forms = await formsRes.json();
+                const submissions = await submissionsRes.json();
+
+                forms.forEach(f => { formsMap[f._id] = f; });
+
+                const formFilter = document.getElementById('formFilter');
+                formFilter.innerHTML = '<option value="">Todos los formularios</option>';
+                forms.forEach(f => {
+                    const option = document.createElement('option');
+                    option.value = f._id;
+                    option.textContent = f.name;
+                    formFilter.appendChild(option);
+                });
+
+                paymentsData = submissions.map(s => {
+                    const form = formsMap[s.formId] || {};
+                    const fieldMap = {};
+                    if (form.fields) {
+                        form.fields.forEach(fl => { fieldMap[fl.id] = fl; });
+                    }
+                    let student = 'N/A';
+                    let studentType = '';
+                    let controlNumber = '';
+                    let captureNumber = '';
+                    s.responses.forEach(r => {
+                        const field = fieldMap[r.fieldId] || {};
+                        const label = (field.label || '').toLowerCase();
+                        if (label.includes('nombre')) student = r.value;
+                        else if (label.includes('línea de captura')) captureNumber = r.value;
+                        else if (label.includes('número de control')) controlNumber = r.value;
+                        else if (label.includes('tipo') && label.includes('estudiante')) studentType = r.value;
+                    });
+                    return {
+                        id: s._id,
+                        formId: s.formId,
+                        formName: form.name || s.formId,
+                        student,
+                        studentType,
+                        controlNumber,
+                        captureNumber,
+                        govValidation: 'pending',
+                        date: s.createdAt,
+                        status: s.status,
+                        files: s.files || [],
+                        observations: []
+                    };
+                });
+
                 filteredData = [...paymentsData];
                 updateStatistics();
                 renderTable();
@@ -625,11 +661,11 @@
 
         let currentPage = 1;
         let itemsPerPage = 10;
-        let filteredData = [...paymentsData];
+        let filteredData = [];
         let selectedPaymentId = null;
 
         document.addEventListener('DOMContentLoaded', function() {
-            loadPayments().then(() => {
+            loadData().then(() => {
                 setupFilters();
                 setupSearch();
             });
@@ -775,7 +811,7 @@
             const searchTerm = document.getElementById('searchInput').value.toLowerCase();
 
             filteredData = paymentsData.filter(payment => {
-                const matchesForm = !formFilter || payment.form === formFilter;
+                const matchesForm = !formFilter || payment.formId === formFilter;
                 const matchesStatus = !statusFilter || payment.status === statusFilter;
                 const matchesValidation = !validationFilter || payment.govValidation === validationFilter;
                 const matchesSearch = !searchTerm || 


### PR DESCRIPTION
## Summary
- add Mongo index for templates
- implement helpers and routes for templates
- use real form submission data in dashboard pagos
- hook dashboard graphs to live stats

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_685bcb81d81c832d84fd19aa818b866f