### PR TITLE
Add script to seed all MongoDB collections with dummy record

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@
 | Commit             | `git commit -m "Mensaje"`     |
 | Subir (push)       | `git push origin main`        |
 | Bajar (pull)       | `git pull origin main`        |
+| Insertar registros de prueba | `npm run add-dummy` |

--- a/addDummyRecords.js
+++ b/addDummyRecords.js
@@ -1,0 +1,23 @@
+const { MongoClient } = require('mongodb');
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '.env') });
+
+async function main() {
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017';
+  const client = new MongoClient(uri);
+  try {
+    await client.connect();
+    const db = client.db('livetext');
+    const collections = await db.collections();
+    for (const coll of collections) {
+      await coll.insertOne({ dummyRecord: true, insertedAt: new Date() });
+      console.log(`Inserted dummy record into ${coll.collectionName}`);
+    }
+  } catch (err) {
+    console.error('Error inserting dummy records:', err);
+  } finally {
+    await client.close();
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "add-dummy": "node addDummyRecords.js"
+  },
   "dependencies": {
     "bcryptjs": "^3.0.2",
     "bull": "^4.16.5",


### PR DESCRIPTION
## Summary
- add `addDummyRecords.js` to insert one test document into each MongoDB collection
- expose the script via `npm run add-dummy`
- document new command in README

## Testing
- `node addDummyRecords.js` *(fails: Cannot find module 'mongodb')*

------
https://chatgpt.com/codex/tasks/task_e_685ebb47ebf4832d96ff32dccd0a6939