### PR TITLE
Feed posts on home page

### DIFF
--- a/app.js
+++ b/app.js
@@ -526,10 +526,11 @@ function parseBool(value) {
 async function createPost(db, postData, files, userId, isDraft = false) {
   console.log('Creating post:', postData, files);
   const { title, content, category, allowComments, mediaMode, tags, date, time, schedulePost } = postData;
-  if (!title || !content) throw new Error('Título y contenido son obligatorios.');
-  const wordCount = content.trim().split(/\s+/).length;
+  if (!title || content === undefined || content === null) throw new Error('Título y contenido son obligatorios.');
+  const contentStr = typeof content === 'string' ? content : String(content);
+  const wordCount = contentStr.trim().split(/\s+/).length;
   if (wordCount > 400) throw new Error('El contenido excede el límite de 400 palabras.');
-  const sanitizedContent = sanitizeHtml(content, {
+  const sanitizedContent = sanitizeHtml(contentStr, {
     allowedTags: ['b', 'i', 'u', 'p', 'br'],
     allowedAttributes: {}
   });
@@ -603,9 +604,10 @@ Equipo LIVETEXT
 async function updatePost(db, postId, postData, files, userId, isDraft = false) {
   console.log('Updating post:', postId, postData, files);
   const { title, content, category, allowComments, mediaMode, tags, date, time, schedulePost } = postData;
-  const wordCount = content.trim().split(/\s+/).length;
+  const contentStr = typeof content === 'string' ? content : String(content);
+  const wordCount = contentStr.trim().split(/\s+/).length;
   if (wordCount > 400) throw new Error('El contenido excede el límite de 400 palabras.');
-  const sanitizedContent = sanitizeHtml(content, {
+  const sanitizedContent = sanitizeHtml(contentStr, {
     allowedTags: ['b', 'i', 'u', 'p', 'br'],
     allowedAttributes: {}
   });

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
     <link href="https://cdn.jsdelivr.net/npm/fullcalendar@5.10.1/main.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/masonry-layout@4.2.2/dist/masonry.pkgd.min.js"></script>
 </head>
 <style>
     :root {
@@ -104,39 +103,32 @@
         transform: scale(1.05);
     }
 
-    .content-grid {
+
+    .posts-feed {
         margin-top: 2rem;
-        column-count: 3;
-        column-gap: 1rem;
     }
 
-    .grid-item {
+    .feed-item {
         background: var(--light-bg);
         border-radius: 10px;
         overflow: hidden;
         margin-bottom: 1rem;
         box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
-        transition: transform 0.3s ease;
-        break-inside: avoid;
     }
 
-    .grid-item:hover {
-        transform: translateY(-5px);
-    }
-
-    .grid-item img,
-    .grid-item video {
+    .feed-item img,
+    .feed-item video {
         width: 100%;
         max-height: 400px;
         object-fit: cover;
     }
 
-    .grid-item .post-content {
+    .feed-item .post-content {
         padding: 1rem;
         color: var(--primary-color);
     }
 
-    .grid-item .post-actions {
+    .feed-item .post-actions {
         display: flex;
         gap: 1rem;
         padding: 0.5rem 1rem;
@@ -421,10 +413,6 @@
     }
 
     @media (max-width: 768px) {
-        .content-grid {
-            column-count: 1;
-        }
-
         .chat-container {
             width: 100%;
             bottom: 0;
@@ -541,12 +529,10 @@
                 </div>
             </div>
 
-            <!-- Grid de publicaciones -->
+            <!-- Feed de publicaciones -->
             <div class="row animate__animated animate__fadeIn">
                 <div class="col-12">
-                    <div class="content-grid" id="publicaciones-container">
-                        <div class="grid-sizer"></div>
-                    </div>
+                    <div class="posts-feed" id="postsFeed"></div>
                 </div>
             </div>
         </div>
@@ -706,12 +692,6 @@
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            const grid = document.querySelector('#publicaciones-container');
-            const masonry = new Masonry(grid, {
-                itemSelector: '.grid-item',
-                columnWidth: '.grid-sizer',
-                percentPosition: true
-            });
 
             // Toggle chat
             const chatButton = document.getElementById('chatButton');
@@ -903,15 +883,15 @@
             // Cargar y mostrar posts
             async function loadPosts(filter = 'all') {
                 try {
-                    const response = await fetch('http://localhost:3000/api/posts');
+                    const response = await fetch('/api/posts');
                     const posts = await response.json();
-                    const container = document.getElementById('publicaciones-container');
-                    container.innerHTML = '<div class="grid-sizer"></div>';
+                    const container = document.getElementById('postsFeed');
+                    container.innerHTML = '';
 
                     const filteredPosts = filter === 'all' ? posts : posts.filter(post => post.category === filter);
                     filteredPosts.forEach(post => {
                         const item = document.createElement('div');
-                        item.className = 'grid-item';
+                        item.className = 'feed-item';
                         item.innerHTML = `
                             <div class="post-media">
                                 ${post.media && post.media.length > 0 ? (post.mediaMode === 'gallery' && post.media.length >= 4 ? `
@@ -961,8 +941,6 @@
                         }
                     });
 
-                    masonry.reloadItems();
-                    masonry.layout();
                 } catch (error) {
                     console.error('Error al cargar posts:', error);
                     document.getElementById('errorToastBody').textContent = 'Error al cargar las publicaciones.';


### PR DESCRIPTION
## Summary
- clean up leftover grid styles and remove unused code
- fetch posts via relative path

## Testing
- `npm run add-dummy` *(fails: SyntaxError in addDummyRecords.js and network restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_686d80355160832d84b3445ba3ebfca7