### PR TITLE
Enhance chat accessibility and layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -699,12 +699,13 @@ async function getPosts(db, page = 1, limit = 10, category = null) {
   if (cached) return JSON.parse(cached);
   const query = { isPublic: true };
   if (category) query.category = category;
-  const posts = await db.collection('posts')
+  let cursor = db.collection('posts')
     .find(query)
-    .sort({ date: -1 })
-    .skip((page - 1) * limit)
-    .limit(limit)
-    .toArray();
+    .sort({ date: -1 });
+  if (limit > 0) {
+    cursor = cursor.skip((page - 1) * limit).limit(limit);
+  }
+  const posts = await cursor.toArray();
   const formattedPosts = posts.map(post => ({
     ...post,
     createdAt: moment.tz(post.createdAt, 'America/Mexico_City').toDate(),
@@ -1200,7 +1201,7 @@ app.post('/api/posts', requireAuth, upload.array('postMedia', 5), async (req, re
 app.get('/api/posts', async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
-    const limit = parseInt(req.query.limit) || 10;
+    const limit = req.query.limit === undefined ? 10 : parseInt(req.query.limit);
     const category = req.query.category || null;
     const posts = await getPosts(db, page, limit, category);
     res.json(posts);
@@ -1850,7 +1851,8 @@ app.post('/api/validate-capture', requireAuth, async (req, res) => {
 });
 
 // Servicio de chat IA utilizando OpenAI
-app.post('/api/chat', requireAuth, async (req, res) => {
+// Se eliminó requireAuth para permitir el uso del chat en la página pública
+app.post('/api/chat', async (req, res) => {
   const { messages } = req.body;
   if (!Array.isArray(messages)) {
     return res.status(400).json({ error: 'Formato de mensajes inválido' });

--- a/private/dashboard.html
+++ b/private/dashboard.html
@@ -787,25 +787,20 @@
             box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
         }
 
+        /* Estilo del chat (coincide con el de index.html) */
         .chat-container {
             position: fixed;
             bottom: 90px;
             right: 20px;
             width: 350px;
-            height: 500px;
+            max-height: 500px;
             background: var(--dark-bg);
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+            border-radius: 10px;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
             display: none;
             flex-direction: column;
             z-index: 1050;
-            overflow: hidden;
-            animation: chatAppear 0.3s forwards;
-        }
-
-        @keyframes chatAppear {
-            from { transform: translateY(50px); opacity: 0; }
-            to { transform: translateY(0); opacity: 1; }
+            animation: slideInRight 0.3s ease;
         }
 
         .infinite-scroll-error,
@@ -1160,6 +1155,44 @@
         </div>
     </footer>
 
+    <!-- Chat flotante -->
+    <div class="floating-button animate__animated animate__bounceIn" id="chatButton">
+        <i class="fas fa-comment-dots"></i>
+    </div>
+    <div class="chat-container" id="chatContainer">
+        <div class="chat-header">
+            <div class="d-flex align-items-center">
+                <button class="btn btn-sm text-white me-2" id="toggleChatType">
+                    <i class="fas fa-robot"></i>
+                </button>
+                <h5 class="chat-title mb-0" id="chatTitle">Chat IA</h5>
+            </div>
+            <button class="close-chat" id="closeChat">
+                <i class="fas fa-times"></i>
+            </button>
+        </div>
+        <div class="chat-messages" id="chatMessages"></div>
+        <div class="quick-options" id="quickOptions">
+            <button class="quick-option">¿Cómo inscribirme?</button>
+            <button class="quick-option">Fechas de cursos</button>
+            <button class="quick-option">Costo de cursos</button>
+            <button class="quick-option">Certificaciones</button>
+        </div>
+        <div class="asesor-info d-none" id="asesorInfo">
+            <div class="p-3 bg-light border-top">
+                <div class="d-flex align-items-center mb-2">
+                    <div class="online-indicator me-2"></div>
+                    <span class="fw-bold" id="asesorNombre">Conectando...</span>
+                </div>
+                <small class="text-muted" id="asesorStatus">Por favor espere...</small>
+            </div>
+        </div>
+        <div class="chat-input-container">
+            <input type="text" class="chat-input" id="chatInput" placeholder="Escribe tu mensaje...">
+            <button class="chat-send" id="chatSend"><i class="fas fa-paper-plane"></i></button>
+        </div>
+    </div>
+
     <!-- Toast Container -->
     <div class="toast-container">
         <div id="errorToast" class="toast align-items-center text-white bg-danger border-0" role="alert"
@@ -1456,6 +1489,86 @@
                     gutter: 20
                 });
             });
+
+            // Chat
+            const chatButton = document.getElementById('chatButton');
+            const chatContainer = document.getElementById('chatContainer');
+            const chatMessages = document.getElementById('chatMessages');
+            const chatInput = document.getElementById('chatInput');
+            const chatSend = document.getElementById('chatSend');
+            const toggleChatType = document.getElementById('toggleChatType');
+            const chatTitle = document.getElementById('chatTitle');
+            const quickOptions = document.getElementById('quickOptions');
+            const asesorInfo = document.getElementById('asesorInfo');
+            const messages = [];
+            let chatInitialized = false;
+
+            chatButton.addEventListener('click', () => {
+                const hidden = chatContainer.style.display === 'none';
+                chatContainer.style.display = hidden ? 'flex' : 'none';
+                if (hidden && !chatInitialized) {
+                    addChatMessage('IA', '¡Hola! ¿En qué puedo ayudarte?');
+                    chatInitialized = true;
+                }
+            });
+            document.getElementById('closeChat').addEventListener('click', () => {
+                chatContainer.style.display = 'none';
+            });
+
+            toggleChatType.addEventListener('click', () => {
+                if (chatTitle.textContent === 'Chat IA') {
+                    chatTitle.textContent = 'Chat con Asesor';
+                    toggleChatType.innerHTML = '<i class="fas fa-robot"></i>';
+                    quickOptions.classList.add('d-none');
+                    asesorInfo.classList.remove('d-none');
+                } else {
+                    chatTitle.textContent = 'Chat IA';
+                    toggleChatType.innerHTML = '<i class="fas fa-user"></i>';
+                    quickOptions.classList.remove('d-none');
+                    asesorInfo.classList.add('d-none');
+                }
+            });
+
+            chatSend.addEventListener('click', sendChatMessage);
+            chatInput.addEventListener('keydown', e => { if (e.key === 'Enter') sendChatMessage(); });
+            document.querySelectorAll('.quick-option').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    chatInput.value = btn.textContent;
+                    sendChatMessage();
+                });
+            });
+
+            function addChatMessage(sender, text) {
+                const div = document.createElement('div');
+                div.className = 'mb-2';
+                div.innerHTML = `<strong>${sender}:</strong> ${text}`;
+                chatMessages.appendChild(div);
+                chatMessages.scrollTop = chatMessages.scrollHeight;
+            }
+
+            async function sendChatMessage() {
+                const text = chatInput.value.trim();
+                if (!text) return;
+                addChatMessage('Tú', text);
+                messages.push({ role: 'user', content: text });
+                chatInput.value = '';
+                try {
+                    const res = await fetch('/api/chat', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ messages })
+                    });
+                    const data = await res.json();
+                    if (res.ok) {
+                        messages.push({ role: 'assistant', content: data.reply });
+                        addChatMessage('IA', data.reply);
+                    } else {
+                        addChatMessage('Error', data.error || 'Error');
+                    }
+                } catch (err) {
+                    addChatMessage('Error', 'No se pudo conectar');
+                }
+            }
         });
 
         function showToast(title, message) {

--- a/public/accessibility.js
+++ b/public/accessibility.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
   .accessibility-toggle {
     position: fixed;
     bottom: 1rem;
-    right: 1rem;
+    left: 1rem;
     z-index: 10000;
   }
   .high-contrast, .high-contrast a {

--- a/public/index.html
+++ b/public/index.html
@@ -107,6 +107,9 @@
 
     .posts-feed {
         margin-top: 2rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
     }
 
     .feed-item {
@@ -116,6 +119,8 @@
         overflow: hidden;
         margin-bottom: 2rem;
         box-shadow: 0 16px 32px rgba(0, 0, 0, 0.4);
+        width: 100%;
+        max-width: 600px;
     }
 
     .feed-item img,
@@ -139,6 +144,21 @@
         display: flex;
         gap: 1rem;
         padding: 0.5rem 1rem;
+    }
+
+    .comments-section {
+        display: none;
+        background: var(--dark-bg);
+        padding: 1rem 2rem;
+        border-top: 1px solid var(--light-bg);
+    }
+
+    .comments-section .comment {
+        margin-bottom: .5rem;
+    }
+
+    .comments-section .replies {
+        margin-left: 1rem;
     }
 
     .newsletter-card {
@@ -664,31 +684,7 @@
         </div>
     </footer>
 
-    <!-- Modal Comentarios -->
-    <div class="modal fade" id="commentsModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content bg-dark text-white">
-                <div class="modal-header">
-                    <h5 class="modal-title">Comentarios</h5>
-                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <div id="commentsList" class="mb-3"></div>
-                    <textarea id="commentInput" class="form-control" placeholder="Escribe un comentario..."></textarea>
-                    <hr>
-                    <div id="modalChatBox" class="border rounded p-2 mb-2" style="height:180px;overflow-y:auto"></div>
-                    <div class="input-group">
-                        <input id="modalChatInput" class="form-control" placeholder="Pregunta a la IA">
-                        <button id="modalChatSend" class="btn btn-primary">Enviar</button>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
-                    <button type="button" class="btn btn-primary" id="sendComment">Enviar</button>
-                </div>
-            </div>
-        </div>
-    </div>
+
 
     <!-- Modal para ver multimedia -->
     <div class="modal fade" id="mediaModal" tabindex="-1" aria-hidden="true">
@@ -739,8 +735,14 @@
             // Toggle chat
             const chatButton = document.getElementById('chatButton');
             const chatContainer = document.getElementById('chatContainer');
+            let chatInitialized = false;
             chatButton.addEventListener('click', () => {
-                chatContainer.style.display = chatContainer.style.display === 'none' ? 'flex' : 'none';
+                const hidden = chatContainer.style.display === 'none';
+                chatContainer.style.display = hidden ? 'flex' : 'none';
+                if (hidden && !chatInitialized) {
+                    addChatMessage('IA', '¡Hola! ¿En qué puedo ayudarte?');
+                    chatInitialized = true;
+                }
             });
 
             // Toggle tipo de chat
@@ -949,7 +951,7 @@
             // Cargar y mostrar posts
             async function loadPosts(filter = 'all') {
                 try {
-                    const response = await fetch('/api/posts');
+                    const response = await fetch('/api/posts?limit=0');
                     const posts = await response.json();
                     const container = document.getElementById('postsFeed');
                     container.innerHTML = '';
@@ -960,10 +962,6 @@
                         item.className = 'feed-item';
 
                         const mediaHtml = post.media && post.media.length > 0 ? (post.mediaMode === 'gallery' && post.media.length >= 4 ? `
-
-                        item.innerHTML = `
-                            <div class="post-media">
-                                ${post.media && post.media.length > 0 ? (post.mediaMode === 'gallery' && post.media.length >= 4 ? `
                                     <div class="preview-media-grid">
                                         ${post.media.map(m => `<${m.contentType.startsWith('image') ? 'img' : 'video'} src="${m.path}" ${m.contentType.startsWith('video') ? 'controls muted' : ''} style="height: 200px; object-fit: cover; border-radius: 12px;">`).join('')}
                                     </div>` : `
@@ -986,6 +984,7 @@
                                         ` : ''}
                                     </div>`)
                                 : '<img src="https://via.placeholder.com/400x300" alt="Placeholder">';
+
                         item.innerHTML = `
                             <div class="post-media">${mediaHtml}</div>
                             <div class="post-content">
@@ -995,6 +994,13 @@
                             </div>
                             <div class="post-actions">
                                 <button class="btn btn-sm btn-secondary comment-btn" data-id="${post._id}" ${post.allowComments ? '' : 'disabled'}>Comentarios</button>
+                            </div>
+                            <div class="comments-section" id="comments-${post._id}">
+                                <div class="comments-list"></div>
+                                <div class="input-group mt-2">
+                                    <textarea class="form-control comment-input" rows="2" placeholder="Escribe un comentario..."></textarea>
+                                    <button class="btn btn-primary send-comment" type="button">Enviar</button>
+                                </div>
                             </div>`;
                         container.appendChild(item);
 
@@ -1009,14 +1015,42 @@
                         });
 
                         const btn = item.querySelector('.comment-btn');
+                        const section = item.querySelector(`#comments-${post._id}`);
+                        const list = section.querySelector('.comments-list');
+                        const input = section.querySelector('.comment-input');
+                        const sendBtn = section.querySelector('.send-comment');
                         if (btn) {
-                            btn.addEventListener('click', () => {
-                                activePost = btn.getAttribute('data-id');
-                                loadComments(activePost);
-                                const modal = new bootstrap.Modal(document.getElementById('commentsModal'));
-                                modal.show();
+                            btn.addEventListener('click', async () => {
+                                if (section.style.display === 'none') {
+                                    await loadComments(post._id, list);
+                                    section.style.display = 'block';
+                                } else {
+                                    section.style.display = 'none';
+                                }
                             });
                         }
+                        sendBtn.addEventListener('click', async () => {
+                            const content = input.value.trim();
+                            const parentId = input.dataset.parentId || null;
+                            if (!content) return;
+                            const res = await fetch(`/api/posts/${post._id}/comments`, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ content, parentId })
+                            });
+                            if (res.ok) {
+                                input.value = '';
+                                input.dataset.parentId = '';
+                                await loadComments(post._id, list);
+                            }
+                        });
+
+                        section.addEventListener('click', e => {
+                            if (e.target.classList.contains('reply-btn')) {
+                                input.dataset.parentId = e.target.dataset.id;
+                                input.focus();
+                            }
+                        });
                     });
 
                 } catch (error) {
@@ -1053,12 +1087,11 @@
                 return div;
             }
 
-            async function loadComments(postId) {
+            async function loadComments(postId, list) {
                 try {
                     const res = await fetch(`/api/posts/${postId}/comments`);
                     const comments = await res.json();
                     const tree = buildCommentTree(comments);
-                    const list = document.getElementById('commentsList');
                     list.innerHTML = '';
                     tree.forEach(c => list.appendChild(renderComment(c)));
                     if (!tree.length) list.innerHTML = '<p>No hay comentarios</p>';
@@ -1067,74 +1100,12 @@
                 }
             }
 
-            let activePost = null;
-            const modalChatBox = document.getElementById('modalChatBox');
-            const modalChatInput = document.getElementById('modalChatInput');
-            const modalChatSend = document.getElementById('modalChatSend');
-            const modalMessages = [];
-
-            function addModalChat(sender, text) {
-                const div = document.createElement('div');
-                div.innerHTML = `<strong>${sender}:</strong> ${text}`;
-                modalChatBox.appendChild(div);
-                modalChatBox.scrollTop = modalChatBox.scrollHeight;
-            }
-
-            async function sendModalChat() {
-                const text = modalChatInput.value.trim();
-                if (!text) return;
-                addModalChat('Tú', text);
-                modalMessages.push({ role: 'user', content: text });
-                modalChatInput.value = '';
-                try {
-                    const res = await fetch('/api/chat', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ messages: modalMessages })
-                    });
-                    const data = await res.json();
-                    if (res.ok) {
-                        modalMessages.push({ role: 'assistant', content: data.reply });
-                        addModalChat('IA', data.reply);
-                    } else {
-                        addModalChat('Error', data.error || 'Error');
-                    }
-                } catch (e) {
-                    addModalChat('Error', 'No se pudo conectar');
-                }
-            }
-
-            modalChatSend.addEventListener('click', sendModalChat);
-            modalChatInput.addEventListener('keydown', e => { if (e.key === 'Enter') sendModalChat(); });
-            document.getElementById('sendComment').addEventListener('click', async () => {
-                const content = document.getElementById('commentInput').value.trim();
-                const parentId = document.getElementById('commentInput').dataset.parentId || null;
-                if (!content || !activePost) return;
-                const res = await fetch(`/api/posts/${activePost}/comments`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ content, parentId })
-                });
-                if (res.ok) {
-                    document.getElementById('commentInput').value = '';
-                    document.getElementById('commentInput').dataset.parentId = '';
-                    await loadComments(activePost);
-                }
-            });
-
-            document.getElementById('commentsModal').addEventListener('hidden.bs.modal', () => {
-                document.getElementById('commentInput').dataset.parentId = '';
-            });
 
             document.addEventListener('click', e => {
                 if (e.target.classList.contains('show-more-link')) {
                     const p = e.target.closest('.expandable');
                     p.innerHTML = p.dataset.full;
                     p.classList.add('expanded');
-                }
-                if (e.target.classList.contains('reply-btn')) {
-                    document.getElementById('commentInput').dataset.parentId = e.target.dataset.id;
-                    document.getElementById('commentInput').focus();
                 }
             });
 


### PR DESCRIPTION
## Summary
- allow public use of the `/api/chat` endpoint
- match the dashboard chat widget styling with index.html
- move accessibility toggle to the left so it doesn't overlap the chat button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686da5c65038832d8d7bf1d1e4af8a39