### PR TITLE
Improve chat and replace alerts

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ const morgan = require('morgan');
 const cookieParser = require('cookie-parser');
 const OpenAI = require('openai');
 const MongoDBStore = require('connect-mongodb-session')(session);
+const bannedWords = ['puta', 'mierda', 'pendejo', 'cabron'];
 const validator = require('validator');
 
 const TRAINING_DATA_FILE = path.join(__dirname, 'training-data.json');
@@ -811,6 +812,10 @@ async function deleteForm(db, formId, userId) {
 async function createComment(db, postId, commentData, visitorId) {
   const { content, parentId } = commentData;
   if (!content) throw new Error('El comentario no puede estar vacío.');
+  const lower = content.toLowerCase();
+  if (bannedWords.some(w => lower.includes(w))) {
+    throw new Error('El comentario contiene lenguaje no permitido.');
+  }
   const sanitizedContent = sanitizeHtml(content, {
     allowedTags: [],
     allowedAttributes: {}
@@ -1879,6 +1884,9 @@ app.post('/api/chat', async (req, res) => {
   }
   try {
     const lastUserMsg = messages.filter(m => m.role === "user").slice(-1)[0]?.content || "";
+    if (bannedWords.some(w => lastUserMsg.toLowerCase().includes(w))) {
+      return res.status(400).json({ error: 'Lenguaje no permitido' });
+    }
     const custom = findAnswer(lastUserMsg);
     if (custom) {
       return res.json({ reply: custom });

--- a/private/chat.html
+++ b/private/chat.html
@@ -9,6 +9,9 @@
     <style>
         body { background: #232A40; color: #fff; }
         #chatBox { background: #fff; color: #000; height: 400px; overflow-y: auto; padding: 10px; border-radius: 5px; }
+        .message { padding: .4rem .6rem; border-radius: .4rem; margin-bottom: .5rem; max-width: 80%; }
+        .message.user { background:#d1e7dd; margin-left:auto; }
+        .message.bot { background:#e2e3e5; }
     </style>
 </head>
 <body class="d-flex flex-column min-vh-100">
@@ -20,6 +23,11 @@
     <div class="container my-4 flex-grow-1">
         <h1 class="mb-4">Chat de Entrenamiento IA</h1>
         <div id="chatBox" class="mb-3"></div>
+        <div id="suggestions" class="mb-3">
+            <span class="badge bg-secondary suggestion me-1">¿Cómo se dice 'hola' en inglés?</span>
+            <span class="badge bg-secondary suggestion me-1">¿Qué significa 'merci'?</span>
+            <span class="badge bg-secondary suggestion">Dime una frase común en francés</span>
+        </div>
         <div class="input-group">
             <input type="text" id="chatInput" class="form-control" placeholder="Escribe tu mensaje...">
             <button id="sendBtn" class="btn btn-primary">Enviar</button>
@@ -36,22 +44,33 @@
         document.getElementById('sendBtn').addEventListener('click', sendMessage);
         document.getElementById('chatInput').addEventListener('keydown', e => { if (e.key === 'Enter') sendMessage(); });
 
-        function addMessage(sender, text) {
+        function addMessage(role, text) {
             const div = document.createElement('div');
-            div.className = 'mb-2';
-            div.innerHTML = `<strong>${sender}:</strong> ${text}`;
+            div.className = `message ${role}`;
+            div.textContent = text;
             const box = document.getElementById('chatBox');
             box.appendChild(div);
             box.scrollTop = box.scrollHeight;
         }
 
+        const banned = ['puta','mierda','pendejo','cabron'];
+        let started = false;
+
         async function sendMessage() {
             const input = document.getElementById('chatInput');
             const text = input.value.trim();
             if (!text) return;
+            if (banned.some(w => text.toLowerCase().includes(w))) {
+                showAlert('Lenguaje no permitido');
+                return;
+            }
             messages.push({ role: 'user', content: text });
-            addMessage('Tú', text);
+            addMessage('user', text);
             input.value = '';
+            if (!started) {
+                document.getElementById('suggestions').style.display = 'none';
+                started = true;
+            }
             try {
                 const res = await fetch('/api/chat', {
                     method: 'POST',
@@ -61,12 +80,12 @@
                 const data = await res.json();
                 if (res.ok) {
                     messages.push({ role: 'assistant', content: data.reply });
-                    addMessage('IA', data.reply);
+                    addMessage('bot', data.reply);
                 } else {
-                    addMessage('Error', data.error || 'Error');
+                    addMessage('bot', data.error || 'Error');
                 }
             } catch (err) {
-                addMessage('Error', 'No se pudo conectar');
+                addMessage('bot', 'No se pudo conectar');
             }
         }
 
@@ -82,13 +101,14 @@
             if (res.ok) {
                 document.getElementById('trainQuestion').value = '';
                 document.getElementById('trainAnswer').value = '';
-                alert('Guardado');
+                showAlert('Guardado');
             } else {
-                alert('Error al guardar');
+                showAlert('Error al guardar');
             }
         });
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/modal.js"></script>
     <script src="accessibility.js"></script>
 </body>
 </html>

--- a/private/crear_post.html
+++ b/private/crear_post.html
@@ -1026,12 +1026,12 @@
             document.getElementById('postMedia').addEventListener('change', e => {
                 const files = Array.from(e.target.files);
                 if (mediaFiles.length + files.length > 5) {
-                    alert('Máximo 5 archivos.');
+                    showAlert('Máximo 5 archivos.');
                     e.target.value = '';
                     return;
                 }
                 if (files.some(f => f.size > MAX_FILE_SIZE)) {
-                    alert('Un archivo supera el límite de 50MB.');
+                    showAlert('Un archivo supera el límite de 50MB.');
                     e.target.value = '';
                     return;
                 }
@@ -1096,6 +1096,7 @@
             updateWordCount();
         });
     </script>
+    <script src="/modal.js"></script>
     <script src="accessibility.js"></script>
 </body>
 </html>

--- a/private/dashboard_documentos.html
+++ b/private/dashboard_documentos.html
@@ -637,7 +637,7 @@ $(document).ready(async () => {
     });
   } catch (error) {
     console.error('Error loading documents:', error);
-    alert('Failed to load documents.');
+    showAlert('Failed to load documents.');
   }
 });
 
@@ -666,6 +666,7 @@ function showConfirm(message) {
     </div>
   </div>
 </div>
+<script src="/modal.js"></script>
 <script src="accessibility.js"></script>
 </body>
 </html>

--- a/private/editar_forms.html
+++ b/private/editar_forms.html
@@ -49,7 +49,7 @@
             document.getElementById('active').checked = data.active;
         } catch (err) {
             console.error(err);
-            alert('Error al cargar el formulario');
+            showAlert('Error al cargar el formulario');
         }
     });
 
@@ -66,14 +66,15 @@
         };
         try {
             await axios.put(`/api/forms/${id}`, payload);
-            alert('Formulario actualizado');
+            showAlert('Formulario actualizado');
             window.location.href = '/dashboard';
         } catch (err) {
             console.error(err);
-            alert('Error al actualizar');
+            showAlert('Error al actualizar');
         }
     });
     </script>
+    <script src="/modal.js"></script>
     <script src="accessibility.js"></script>
 </body>
 </html>

--- a/private/editar_posts.html
+++ b/private/editar_posts.html
@@ -1062,12 +1062,12 @@
             document.getElementById('postMedia').addEventListener('change', e => {
                 const files = Array.from(e.target.files);
                 if (mediaFiles.length + files.length > 5) {
-                    alert('Máximo 5 archivos.');
+                    showAlert('Máximo 5 archivos.');
                     e.target.value = '';
                     return;
                 }
                 if (files.some(f => f.size > MAX_FILE_SIZE)) {
-                    alert('Un archivo supera el límite de 50MB.');
+                    showAlert('Un archivo supera el límite de 50MB.');
                     e.target.value = '';
                     return;
                 }
@@ -1166,6 +1166,7 @@
                 });
         });
     </script>
+    <script src="/modal.js"></script>
     <script src="accessibility.js"></script>
 </body>
 </html>

--- a/public/accessibility.js
+++ b/public/accessibility.js
@@ -14,6 +14,9 @@ document.addEventListener('DOMContentLoaded', () => {
     left: 1rem;
     z-index: 10000;
   }
+  #screenReaderToggle {
+    left: 7rem;
+  }
   .high-contrast, .high-contrast a {
     background-color: #000 !important;
     color: #fff !important;

--- a/public/editor.js
+++ b/public/editor.js
@@ -25,12 +25,14 @@ let autofillFields = [];
 let excelRows = [];
 
 // Utility: show a Bootstrap modal instead of alert()
-window.showAlert = function(message, title = 'Aviso') {
-  $('#alert-modal-title').text(title);
-  $('#alert-modal-body').text(message);
-  const modal = new bootstrap.Modal(document.getElementById('alert-modal'));
-  modal.show();
-};
+if (!window.showAlert) {
+  window.showAlert = function(message, title = 'Aviso') {
+    $('#alert-modal-title').text(title);
+    $('#alert-modal-body').text(message);
+    const modal = new bootstrap.Modal(document.getElementById('alert-modal'));
+    modal.show();
+  };
+}
 
 // Page dimensions in mm
 const pageSizes = {

--- a/public/modal.js
+++ b/public/modal.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (!document.getElementById('alert-modal')) {
+    const modalHtml = `
+<div class="modal fade" id="alert-modal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="alert-modal-title">Aviso</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body" id="alert-modal-body"></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Aceptar</button>
+      </div>
+    </div>
+  </div>
+</div>`;
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+  }
+});
+
+window.showAlert = window.showAlert || function(message, title = 'Aviso') {
+  document.getElementById('alert-modal-title').textContent = title;
+  document.getElementById('alert-modal-body').textContent = message;
+  const modal = new bootstrap.Modal(document.getElementById('alert-modal'));
+  modal.show();
+};

--- a/public/pagos.html
+++ b/public/pagos.html
@@ -628,7 +628,7 @@
                                 preview.style.display = file.type === 'application/pdf' ? 'none' : 'block';
                                 preview.classList.add('animate__animated', 'animate__zoomIn');
                             } else {
-                                alert('Por favor, sube una imagen JPG, PNG o PDF válida (máximo 5MB).');
+                                showAlert('Por favor, sube una imagen JPG, PNG o PDF válida (máximo 5MB).');
                                 fileInput.value = '';
                                 preview.style.display = 'none';
                             }
@@ -676,34 +676,34 @@
 
                     // Client-side validation
                     if (type === 'email' && value && !validator.isEmail(value)) {
-                        alert('Por favor, ingresa un correo electrónico válido.');
+                        showAlert('Por favor, ingresa un correo electrónico válido.');
                         validationFailed = true;
                         return;
                     }
                     if (type === 'tel' && value && !/^\+?\d{10,15}$/.test(value)) {
-                        alert('Por favor, ingresa un número de teléfono válido (10-15 dígitos).');
+                        showAlert('Por favor, ingresa un número de teléfono válido (10-15 dígitos).');
                         validationFailed = true;
                         return;
                     }
                     if (type === 'number' && value) {
                         const maxDigits = parseInt(input.getAttribute('maxlength') || '10');
                         if (!/^\d+$/.test(value)) {
-                            alert('Por favor, ingresa un número válido.');
+                            showAlert('Por favor, ingresa un número válido.');
                             validationFailed = true;
                             return;
                         }
                         if (value.length > maxDigits) {
-                            alert(`El campo ${field.querySelector('label').textContent} debe tener máximo ${maxDigits} dígitos.`);
+                            showAlert(`El campo ${field.querySelector('label').textContent} debe tener máximo ${maxDigits} dígitos.`);
                             validationFailed = true;
                             return;
                         }
                         if (field.querySelector('label').textContent.toLowerCase().includes('línea de captura') && value.length !== 27) {
-                            alert('La línea de captura debe tener exactamente 27 dígitos.');
+                            showAlert('La línea de captura debe tener exactamente 27 dígitos.');
                             validationFailed = true;
                             return;
                         }
                         if (field.querySelector('label').textContent.toLowerCase().includes('número de control') && value.length !== 9) {
-                            alert('El número de control debe tener exactamente 9 dígitos.');
+                            showAlert('El número de control debe tener exactamente 9 dígitos.');
                             validationFailed = true;
                             return;
                         }
@@ -736,7 +736,7 @@
                     bootstrap.Modal.getInstance(paymentModal).hide();
                 } catch (error) {
                     console.error('Error al enviar formulario:', error);
-                    alert(error.response?.data?.error || 'Error al enviar el formulario. Por favor, intenta de nuevo.');
+                    showAlert(error.response?.data?.error || 'Error al enviar el formulario. Por favor, intenta de nuevo.');
                 }
             });
 
@@ -761,6 +761,7 @@
             });
         });
     </script>
+    <script src="/modal.js"></script>
     <script src="accessibility.js"></script>
 </body>
 </html>

--- a/training-data.json
+++ b/training-data.json
@@ -399,4 +399,29 @@
     "question": "¿Puedo acreditar inglés con el CLE para titulación?",
     "answer": "Sí, si cumples con los niveles requeridos por tu carrera."
   }
+,
+  {
+    "question": "¿Cómo se dice 'hola' en inglés?",
+    "answer": "Se dice 'hello'."
+  },
+  {
+    "question": "¿Cómo se dice 'buenos días' en francés?",
+    "answer": "Se dice 'bonjour'."
+  },
+  {
+    "question": "¿Cómo pregunto la hora en inglés?",
+    "answer": "Puedes decir: 'What time is it?'"
+  },
+  {
+    "question": "Dime una frase común en francés",
+    "answer": "Parlez-vous français? significa '¿Habla usted francés?'"
+  },
+  {
+    "question": "¿Cuál es la diferencia entre 'who' y 'whom'?",
+    "answer": "'Who' se usa como sujeto y 'whom' como objeto de la oración."
+  },
+  {
+    "question": "¿Qué significa 'merci'?",
+    "answer": "Significa 'gracias' en francés."
+  }
 ]


### PR DESCRIPTION
## Summary
- global modal-based `showAlert` utility
- position screen reader toggle to avoid overlap
- modern chat UI with suggestions and profanity filter
- replace alerts in post and form pages
- filter bad words in comments and chat
- expand training data with English and French phrases

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686fa4088614832d9dcd6cbfe9ec0587